### PR TITLE
Armondhonore https protocol check

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -40,5 +40,6 @@ export default {
     version:version,
     build:build,
     host_ip : env === 'development' ? dev_device_ip : window.location.hostname,
-    host_port: env === 'development' ? dev_device_port : (window.location.port && parseInt(window.location.port) !== 80 ? `:${window.location.port}` : '')
+    host_port: env === 'development' ? dev_device_port : (window.location.port && parseInt(window.location.port) !== 80 ? `:${window.location.port}` : ''),
+    http_protocol: window.location.protocol
 }

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -24,7 +24,7 @@ import axios from 'axios';
 import Config from '@/config.js';
 
 const http = axios.create({
-    baseURL: `http://${Config.host_ip}${Config.host_port}/api`,
+    baseURL: `${Config.http_protocol}//${Config.host_ip}${Config.host_port}/api`,
     withCredentials: true
 });
 


### PR DESCRIPTION
This is a simple request on the cue.js code that will allow for an https redirect from an nginx or other ever proxy from the local http port.

I am doing a localhost reverse proxy from port 80 to 443 with nginx with ssl termination. Because the the client javascript used a FQDN with protocol a reverse proxy fails because it still try to communicate over http. 