### PR TITLE
feat: implement header menu toggle functionality

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -39,7 +39,6 @@
       :lock-states="lockStates"
       :is-touch-device="isTouchDevice"
       :handle-toggle-change="handleToggleChange"
-      :toggle-pin="togglePin"
     />
   </v-footer>
 </template>
@@ -95,7 +94,7 @@ const hasActiveComponents = computed(() =>
 )
 
 const shouldShowFooter = computed(() => 
-  hasActiveComponents.value || footer.value.showFooter || footer.value.pinnedFooter
+  footer.value.showFooter
 )
 
 // Business rules for component exclusions
@@ -177,12 +176,6 @@ function handleToggleChange(newToggles) {
   updateVisibility(newToggles)
 }
 
-function togglePin() {
-  footer.value.pinnedFooter = !footer.value.pinnedFooter
-  if (footer.value.pinnedFooter) {
-    footer.value.showFooter = true // Keep menu visible when pinned
-  }
-}
 
 // State synchronization with device store
 watch(() => device.value.showSSHTerminal, (newValue) => {

--- a/src/components/AppHeaderMenu.vue
+++ b/src/components/AppHeaderMenu.vue
@@ -1,0 +1,143 @@
+<template>
+  <v-toolbar
+    height="30"
+    elevation="10"
+    app="false"
+    dense
+    short
+    flat
+    color="black"
+    class="user-menu-toolbar"
+  >
+    <!-- Layout Controls Button Group -->
+    <v-btn-group variant="elevated" color="black" class="layout-btn-group">
+      <v-tooltip location="bottom" content-class="">
+        <template v-slot:activator="{ props: tooltipProps }">
+          <v-btn
+            v-bind="tooltipProps"
+            class="layout-btn"
+            :class="{ 'active-toggle': settings.isVisible }"
+            icon
+            size="small"
+            variant="tonal"
+            @click="handleLayoutClick('left')"
+          >
+            <v-icon :color="settings.isVisible ? '#76FF03' : 'white'">mdi-dock-left</v-icon>
+          </v-btn>
+        </template>
+        <span>Toggle settings</span>
+      </v-tooltip>
+
+      <v-tooltip location="bottom" content-class="">
+        <template v-slot:activator="{ props: tooltipProps }">
+          <v-btn
+            v-bind="tooltipProps"
+            class="layout-btn"
+            :class="{ 'active-toggle': footer.showFooter }"
+            icon
+            size="small"
+            variant="tonal"
+            @click="handleLayoutClick('bottom')"
+          >
+            <v-icon :color="footer.showFooter ? '#76FF03' : 'white'">mdi-dock-bottom</v-icon>
+          </v-btn>
+        </template>
+        <span>Toggle footer</span>
+      </v-tooltip>
+<!--
+      <v-tooltip location="bottom" content-class="">
+        <template v-slot:activator="{ props: tooltipProps }">
+          <v-btn
+            v-bind="tooltipProps"
+            class="layout-btn"
+            icon
+            size="small"
+            @click="handleLayoutClick('layout')"
+          >
+            <v-icon color="white">mdi-dock-right</v-icon>
+          </v-btn>
+        </template>
+        <span>Layout mode</span>
+      </v-tooltip>
+
+-->    </v-btn-group>
+
+    <v-spacer></v-spacer>
+
+    <!-- User Menu -->
+    <v-menu offset-y>
+      <template v-slot:activator="{ props: menuProps }">
+        <v-tooltip location="bottom" content-class="">
+          <template v-slot:activator="{ props: tooltipProps }">
+            <v-btn
+              v-bind="{ ...menuProps, ...tooltipProps }"
+              class="user-menu-button"
+              icon
+              size="small"
+              variant="elevated"
+              color="black"
+            >
+              <v-icon color="white">mdi-account-circle</v-icon>
+            </v-btn>
+          </template>
+          <span>{{ account.user }} </span>
+        </v-tooltip>
+      </template>
+      <v-list>
+        <template v-for="item in menuItems" :key="item.id">
+          <v-divider v-if="item.isDivider"></v-divider>
+          <v-list-item v-else @click="handleUserClick(item.id)">
+            <template v-slot:prepend>
+              <v-icon>{{ item.icon }}</v-icon>
+            </template>
+            <v-list-item-title>{{ $t(item.titleKey) }}</v-list-item-title>
+          </v-list-item>
+        </template>
+      </v-list>
+    </v-menu>
+  </v-toolbar>
+</template>
+
+<script setup>
+  import { useHeaderMenu } from '@/composables/useHeaderMenu';
+
+  const {
+    account,
+    settings,
+    footer,
+    menuItems,
+    handleLayoutClick,
+    handleUserClick,
+  } = useHeaderMenu();
+</script>
+
+<style scoped>
+  .user-menu-toolbar {
+    position: fixed;
+    top: 7px;
+    right: 10px;
+    z-index: 999;
+    width: auto;
+    border-radius: 30px;
+  }
+
+  .layout-btn-group {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+    border-radius: 16px;
+    overflow: hidden;
+  }
+
+  .user-menu-button {
+    border-radius: 50%;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  }
+
+
+  .layout-btn-group .v-btn {
+    border-right: none !important;
+  }
+
+  .layout-btn-group .v-btn:not(:last-child) {
+    border-right: none !important;
+  }
+</style>

--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -2,7 +2,16 @@
   <v-navigation-drawer v-if="settings.isVisible" permanent width="500">
     <!-- HEADER SECTION background-image: url('/bg-2.jpg'); background-size: cover; -->
     <template #prepend>
-      <v-img src="/bg-2.jpg">
+      <v-img src="/bg-2.jpg" style="position: relative">
+        <!-- Close button -->
+        <v-btn
+          icon="mdi-close"
+          variant="text"
+          size="small"
+          style="position: absolute; top: 8px; right: 8px; z-index: 10;"
+          @click="settings.isVisible = false"
+        />
+        
         <div class="text-h4 text-center mb-0 font-weight-medium" style="color: #76ff03">
           BliKVM Matrix
           <v-btn
@@ -38,34 +47,11 @@
         <Settings />
       </v-tabs-window-item>
     </v-tabs-window>
-
-    <template #append>
-      <v-divider />
-
-      <div class="d-flex pa-4 ga-2 justify-start align-center justify-space-around">
-        <v-tooltip v-for="(item, i) in appendItems" :key="i" location="top">
-          <template v-slot:activator="{ props }">
-            <v-btn
-              v-bind="props"
-              height="32"
-              :icon="item.icon"
-              rounded="lg"
-              size="small"
-              variant="text"
-              width="32"
-              @click="item.onClick"
-            >
-              <v-icon color="#76FF03" />
-            </v-btn>
-          </template>
-          <span class="custom-tooltip">{{ item.tooltip }}</span>
-        </v-tooltip>
-      </div>
-    </template>
   </v-navigation-drawer>
 </template>
 
 <script setup>
+  import { ref } from 'vue';
   import { useAppStore } from '@/stores/stores';
   import { storeToRefs } from 'pinia';
   import { useDevice } from '@/composables/useDevice';

--- a/src/components/AppOverlay.vue
+++ b/src/components/AppOverlay.vue
@@ -16,7 +16,7 @@
     <!-- top control bar-->
     <div
       class="overlay-control-bar d-flex w-100 ga-3 pa-1 justify-end align-center"
-      style="margin-top: 0px; margin-right: 40px"
+      style="margin-top: 45px; margin-right: 40px"
     >
       <KvmHandRaise v-if="isExperimental" />
       <KvmClipboard v-if="isExperimental" />

--- a/src/components/SettingsTextPaste.vue
+++ b/src/components/SettingsTextPaste.vue
@@ -55,7 +55,7 @@
           <v-row dense no-gutters>
             <v-col cols="auto" class="d-flex align-center">
               <div class="d-flex align-center pa-1 ga-1">
-                <span class="text-no-wrap">{{ $t('settings.text.paste.keymap') }}:</span>
+                <span class="text-no-wrap">{{ $t('settings.text.paste.keymap') }} </span>
                 <v-select
                   v-model="paste.selectedKeymap"
                   :items="keymapOptions"
@@ -71,7 +71,7 @@
                   color="#76FF03"
                   @click.stop
                 />
-                <span class="text-no-wrap ml-3">{{ $t('settings.text.paste.delay') }}:</span>
+                <span class="text-no-wrap ml-3">{{ $t('settings.text.paste.delay') }} </span>
                 <v-text-field
                   v-model.number="paste.characterDelay"
                   type="number"

--- a/src/components/footer/AppFooterNavigation.vue
+++ b/src/components/footer/AppFooterNavigation.vue
@@ -1,25 +1,13 @@
 <template>
   <!-- Navigation bar -->
   <v-row 
-    v-if="footer.showFooter || footer.pinnedFooter" 
+    v-if="footer.showFooter" 
     no-gutters 
     dense 
     align="center" 
     class="w-100" 
     style="height: 40px"
   >
-    <!-- Pin button -->
-    <v-col order="first" class="d-flex justify-start align-center">
-      <v-icon
-        color="#76FF03"
-        :class="{ 'pin-active': footer.pinnedFooter }"
-        @click.stop="togglePin"
-      >
-        {{ footer.pinnedFooter ? "mdi-pin-outline" : "mdi-pin-off-outline" }}
-      </v-icon>
-    </v-col>
-
-    <v-spacer />
     <v-spacer />
 
     <!-- Navigation toggle buttons -->
@@ -52,8 +40,9 @@
 
     <v-spacer />
 
-    <!-- Current key press indicator -->
-    <v-col class="d-flex justify-end align-center pa-0 ma-0">
+
+    <v-col order="last" class="d-flex justify-end align-center pa-0 ma-0">
+      <!-- Current key press indicator -->
       <v-chip
         v-if="device.hid.keyboard.keyPress"
         grow
@@ -65,12 +54,8 @@
       >
         {{ device.hid.keyboard.keyPress }}
       </v-chip>
-    </v-col>
 
-    <v-divider class="mx-3" inset vertical />
-
-    <!-- Lock state indicators -->
-    <v-col order="last" class="d-flex justify-end align-center pa-0 ma-0">
+      <!-- Lock state indicators -->
       <v-chip
         v-for="lock in lockStates"
         :key="lock.name"
@@ -115,10 +100,6 @@ const props = defineProps({
     type: Function,
     required: true
   },
-  togglePin: {
-    type: Function,
-    required: true
-  }
 });
 
 // Composables

--- a/src/composables/useCursors.js
+++ b/src/composables/useCursors.js
@@ -12,26 +12,26 @@ export function useCursors() {
     {
       icon: 'mdi-cursor-default',
       cursor: 'default',
-      label: 'Default cursor',
+      label: 'default cursor',
       color: '',
     },
     {
       icon: 'mdi-cursor-move',
       cursor: 'grab',
-      label: 'Grab cursor',
+      label: 'grab cursor',
       color: '',
     },
-    { icon: 'mdi-plus', cursor: 'crosshair', label: 'Cell cursor', color: '' },
+    { icon: 'mdi-plus', cursor: 'crosshair', label: 'cell cursor', color: '' },
     {
       icon: 'mdi-cursor-text',
       cursor: 'text',
-      label: 'Text cursor',
+      label: 'text cursor',
       color: '',
     },
     {
       icon: 'mdi-circle-medium',
       cursor: 'cursor-green-dot',
-      label: 'Green dot',
+      label: 'green dot',
       color: '#76FF03',
     },
   ]);

--- a/src/composables/useHeaderMenu.js
+++ b/src/composables/useHeaderMenu.js
@@ -1,0 +1,81 @@
+import { useAppStore } from '@/stores/stores';
+import { storeToRefs } from 'pinia';
+import { useSessionUtils } from '@/composables/useSessionUtils';
+import { useDevice } from '@/composables/useDevice';
+import { useRouter } from 'vue-router';
+
+export function useHeaderMenu() {
+  const store = useAppStore();
+  const { device } = useDevice();
+  const { settings, footer, showManageAccountDialog, showAboutPageDialog, account } = storeToRefs(store);
+  const { inactivateDevice } = useSessionUtils(device);
+  const router = useRouter();
+
+  const handleLayoutClick = (action) => {
+    switch (action) {
+      case 'left':
+        settings.value.isVisible = !settings.value.isVisible;
+        break;
+      case 'bottom':
+        footer.value.showFooter = !footer.value.showFooter;
+        break;
+      default:
+        break;
+    }
+  };
+
+  const menuItems = [
+    {
+      id: 'about',
+      icon: 'mdi-information-outline',
+      titleKey: 'appFooter.about',
+      action: () => {
+        showAboutPageDialog.value = true;
+      }
+    },
+    {
+      id: 'account',
+      icon: 'mdi-account',
+      titleKey: 'account.title',
+      action: () => {
+        showManageAccountDialog.value = true;
+      }
+    },
+    {
+      id: 'divider',
+      isDivider: true
+    },
+    {
+      id: 'logout',
+      icon: 'mdi-logout',
+      titleKey: 'login.logout',
+      action: () => {
+        inactivateDevice();
+        router.push('/');
+      }
+    }
+  ];
+
+  const handleUserClick = (action) => {
+    const item = menuItems.find(item => item.id === action);
+    if (item && item.action) {
+      item.action();
+    }
+  };
+
+  return {
+    // Store refs
+    account,
+    settings,
+    footer,
+    showManageAccountDialog,
+    showAboutPageDialog,
+    
+    // Menu data
+    menuItems,
+    
+    // Actions
+    handleLayoutClick,
+    handleUserClick,
+  };
+}

--- a/src/pages/Matrix.vue
+++ b/src/pages/Matrix.vue
@@ -19,6 +19,7 @@
           ></v-progress-linear>
 
           <AppToolbar :z-index="zIndex.toolbar" class="toolbar" />
+          <AppHeaderMenu />
 
           <div class="video-center-wrapper">
             <AppKVM />
@@ -47,6 +48,7 @@
   import { useDevice } from '@/composables/useDevice';
   import { useAbility } from '@casl/vue';
   import AppToolbar from '@/components/AppToolbar.vue';
+  import AppHeaderMenu from '@/components/AppHeaderMenu.vue';
   import Reconnect from '@/components/Reconnect.vue';
   import DialogManageAccount from '@/components/dialog/DialogManageAccount.vue';
   import DialogCtrlAltDelConfirm from '@/components/dialog/DialogCtrlAltDelConfirm.vue';
@@ -66,15 +68,10 @@
   // TODO 2025-05-18 this needs to be move elsewhere
   const handleMouseMove = (event) => {
     const mouseY = event.clientY;
-    const containerHeight = event.currentTarget.clientHeight;
 
     // Show toolbar if near the top
     if (toolbar.value) {
       toolbar.value.visible = mouseY <= 50;
-    }
-    // Show footer if near the bottom (assumes 600px total height)
-    if (footer.value) {
-      footer.value.showFooter = mouseY >= containerHeight - 30;
     }
   };
 

--- a/src/stores/stores.js
+++ b/src/stores/stores.js
@@ -342,7 +342,6 @@ export const useAppStore = defineStore('app', {
     },
     footer: {
       showFooter: true,
-      pinnedFooter: true,
     },
     ocr: {
       isMenuActive: false,


### PR DESCRIPTION
PR (27) has to be merged before PR 25 <===========

- Add AppHeaderMenu component with settings and footer toggle buttons
- Position keypress indicator directly left of caps lock in footer navigation
- Add close icon to navigation drawer in top-right corner
- Remove proximity-based footer show/hide logic
- Remove unused pinnedFooter property from store
- Integrate header menu into Matrix layout